### PR TITLE
IPFS Cluster support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       MONGODB_URI: "mongodb://<ip-address:<port-number>/" # Line to connect to Mongo DB
       MONGO_DATABASE_NAME: "" # collection name
       PRODUCTION_ENVIRONMENT: false  # Leave "no" if you want testing credentials to work
+      IPFS_GATEWAY_ADDRESS: "" # Default is: "https://gateway.ipfs.io/ipfs/"
       LOCAL_IPFS_ENABLED: true  # Whether to enable local IPFS node publishing or not.      
       LOCAL_IPFS_IS_CLUSTER_PEER: true # Weather LOCAL_IPFS_LIST for cluster-peer or node
       LOCAL_IPFS_LIST: "/ipv4/0.0.0.0/tcp/8888/http,/ipv4/1.1.1.1/tcp/8888/http"  # use your culster-peer OR node `ip` and `port`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,14 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "~/.cache/pip/:/root/.cache/pip"
     environment:
-      LOCAL_IPFS_IS_CLUSTER_PEER: true # Weather LOCAL_IPFS_LIST for cluster-peer or node
       MONGODB_URI: "mongodb://<ip-address>:<port-number>/" # Line to connect to Mongo DB
+      MONGO_DATABASE_NAME: "" # collection name
+      LOCAL_IPFS_ENABLED: true  # Whether to enable local IPFS node publishing or not.      
+      LOCAL_IPFS_IS_CLUSTER_PEER: true # Weather LOCAL_IPFS_LIST for cluster-peer or node
       LOCAL_IPFS_LIST: "/ipv4/0.0.0.0/tcp/8888/http,/ipv4/1.1.1.1/tcp/8888/http"  # use your culster-peer OR node `ip` and `port`
       IPFS_GATEWAY_ADDRESS: "" # Default is: "https://gateway.ipfs.io/ipfs/"
-      MONGO_DATABASE_NAME: "" # collection name
-      PRODUCTION_ENVIRONMENT: false  # Leave "no" if you want testing credentials to work
-      LOCAL_IPFS_ENABLED: true  # Whether to enable local IPFS node publishing or not.      
       PINATA_ENABLED: false  # Whether to upload files to Pinata.cloud or not
       PINATA_API: ''  # Pinata.cloud credentials. Leave empty if you don't need it
       PINATA_SECRET_API: ''  # Pinata.cloud credentials. Leave empty if you don't need it
+      PRODUCTION_ENVIRONMENT: false  # Leave "no" if you want testing credentials to work
       AUTHENTICATE: false # Whether check authentication or not

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "~/.cache/pip/:/root/.cache/pip"
     environment:
-      MONGODB_URI: "mongodb://<ip-address:<port-number>/" # Line to connect to Mongo DB
+      MONGODB_URI: "mongodb://<ip-address>:<port-number>/" # Line to connect to Mongo DB
       MONGO_DATABASE_NAME: "" # collection name
       PRODUCTION_ENVIRONMENT: false  # Leave "no" if you want testing credentials to work
       IPFS_GATEWAY_ADDRESS: "" # Default is: "https://gateway.ipfs.io/ipfs/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   feecc-ipfs-gateway:
+    container_name: feecc_ipfs_gateway
     build:
       context: ./
       dockerfile: Dockerfile
@@ -11,27 +12,14 @@ services:
       - "/etc/timezone:/etc/timezone:ro"
       - "/etc/localtime:/etc/localtime:ro"
       - "~/.cache/pip/:/root/.cache/pip"
-    links:
-      - ipfsnode
-    depends_on:
-      ipfsnode:
-        condition: service_healthy
     environment:
-      MONGODB_URI: ""
-      MONGO_DATABASE_NAME: ""
+      MONGODB_URI: "mongodb://<ip-address:<port-number>/" # Line to connect to Mongo DB
+      MONGO_DATABASE_NAME: "" # collection name
       PRODUCTION_ENVIRONMENT: false  # Leave "no" if you want testing credentials to work
-      LOCAL_IPFS_ENABLED: true  # Whether to enable local IPFS node publishing or not.
-      PY_IPFS_HTTP_CLIENT_DEFAULT_ADDR: '/dns/ipfsnode/tcp/5001/http'  # Node address, don't change
-      PINATA_ENABLED: true  # Whether to upload files to Pinata.cloud or not
+      LOCAL_IPFS_ENABLED: true  # Whether to enable local IPFS node publishing or not.      
+      LOCAL_IPFS_IS_CLUSTER_PEER: true # Weather LOCAL_IPFS_LIST for cluster-peer or node
+      LOCAL_IPFS_LIST: "/ipv4/0.0.0.0/tcp/8888/http,/ipv4/1.1.1.1/tcp/8888/http"  # use your culster-peer OR node `ip` and `port`
+      PINATA_ENABLED: false  # Whether to upload files to Pinata.cloud or not
       PINATA_API: ''  # Pinata.cloud credentials. Leave empty if you don't need it
       PINATA_SECRET_API: ''  # Pinata.cloud credentials. Leave empty if you don't need it
-      AUTHENTICATE: true # Whether check authentication or not
-
-  ipfsnode:
-    image: ipfs/go-ipfs:master-latest
-    restart: always
-    volumes:
-      - ~/ipfs/ipfs_staging:/export
-      - ~/ipfs/ipfs_data:/data/ipfs
-    healthcheck:
-      interval: 5s
+      AUTHENTICATE: false # Whether check authentication or not

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,13 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "~/.cache/pip/:/root/.cache/pip"
     environment:
+      LOCAL_IPFS_IS_CLUSTER_PEER: true # Weather LOCAL_IPFS_LIST for cluster-peer or node
       MONGODB_URI: "mongodb://<ip-address>:<port-number>/" # Line to connect to Mongo DB
+      LOCAL_IPFS_LIST: "/ipv4/0.0.0.0/tcp/8888/http,/ipv4/1.1.1.1/tcp/8888/http"  # use your culster-peer OR node `ip` and `port`
+      IPFS_GATEWAY_ADDRESS: "" # Default is: "https://gateway.ipfs.io/ipfs/"
       MONGO_DATABASE_NAME: "" # collection name
       PRODUCTION_ENVIRONMENT: false  # Leave "no" if you want testing credentials to work
-      IPFS_GATEWAY_ADDRESS: "" # Default is: "https://gateway.ipfs.io/ipfs/"
       LOCAL_IPFS_ENABLED: true  # Whether to enable local IPFS node publishing or not.      
-      LOCAL_IPFS_IS_CLUSTER_PEER: true # Weather LOCAL_IPFS_LIST for cluster-peer or node
-      LOCAL_IPFS_LIST: "/ipv4/0.0.0.0/tcp/8888/http,/ipv4/1.1.1.1/tcp/8888/http"  # use your culster-peer OR node `ip` and `port`
       PINATA_ENABLED: false  # Whether to upload files to Pinata.cloud or not
       PINATA_API: ''  # Pinata.cloud credentials. Leave empty if you don't need it
       PINATA_SECRET_API: ''  # Pinata.cloud credentials. Leave empty if you don't need it

--- a/src/app.py
+++ b/src/app.py
@@ -83,6 +83,7 @@ async def publish_file_as_upload(
             f.write(file_data.file.read())
 
         cid, uri = await publish_file(Path(path), background_tasks)
+        os.remove(path)
         message = f"File {file_data.filename} published"
         logger.info(message)
         return IpfsPublishResponse(status=status.HTTP_200_OK, details=message, ipfs_cid=cid, ipfs_link=uri)

--- a/src/io_gateway/ipfs.py
+++ b/src/io_gateway/ipfs.py
@@ -49,15 +49,17 @@ def publish_to_ipfs(file: tp.Union[os.PathLike[tp.AnyStr], tp.IO[bytes]]) -> tp.
     logger.info("Publishing file to IPFS")
     ipfs_cluster_peer_sockets = set(a.split("/")[2]+":"+a.split("/")[4] for a in tuple(LOCAL_IPFS_LIST.split(",")))
     socket = None
+
     for s in ipfs_cluster_peer_sockets:
         if _check_connection_to_ipfs_cluster_peer(s):
             socket = s
             break
-    try:
-        assert socket != None
-    except AssertionError:
-        logger.error("It seems like there is no alive IPFS CLUSTER peer")
+
+    if socket == None:
+        raise ConnectionError("It seems like there is no alive IPFS CLUSTER peer")
+
     url = _build_url(LOCAL_IPFS_IS_CLUSTER_PEER, 'http', socket, '/add')
+
     with open(file, 'rb') as fout:
         files = {'upload_file': fout}
         result = requests.post(url, files=files).json()

--- a/src/io_gateway/ipfs.py
+++ b/src/io_gateway/ipfs.py
@@ -4,53 +4,67 @@ import os
 import typing as tp
 from time import sleep
 
-import ipfshttpclient2 as ipfshttpclient
 from loguru import logger
 from typed_getenv import getenv
+import requests
 
 LOCAL_IPFS_ENABLED: bool = getenv("LOCAL_IPFS_ENABLED", var_type=bool, default=False, optional=True)
 IPFS_GATEWAY_ADDRESS: str = getenv(
     "IPFS_GATEWAY_ADDRESS", var_type=str, default="https://gateway.ipfs.io/ipfs/", optional=True
 )
-
+LOCAL_IPFS_LIST: str = getenv(
+    "LOCAL_IPFS_LIST", \
+    var_type=str, \
+    default=None, \
+    optional=True
+)
+LOCAL_IPFS_IS_CLUSTER_PEER: bool = getenv("LOCAL_IPFS_IS_CLUSTER_PEER", var_type=bool, default=False, optional=True)
 
 @logger.catch(reraise=True)
-def _get_ipfs_client() -> tp.Optional[ipfshttpclient.Client]:
+def _build_url(mode, protocol, socket, endpoint):
+    return f'{protocol}://{socket}{"" if mode else "/api/v0"}{endpoint}'
 
-    if not LOCAL_IPFS_ENABLED:
-        logger.warning("IPFS capabilities are disabled")
-        return None
-
-    retry_delay = 5
-    for i in range(5):
-        try:
-            client = ipfshttpclient.connect()
-            logger.info("Successfully connected to the IPFS node")
-            return client
-
-        except Exception as e:
-            logger.error(f"An error occurred while getting IPFS client: {e}")
-            logger.warning(f"Attempt {i + 1} failed. Retrying in {retry_delay} s.")
-            sleep(retry_delay)
-
-    logger.warning("Retry attempts count exceeded. Connection to an IPFS node could not be established.")
-    return None
-
-
-IPFS_CLIENT: tp.Optional[ipfshttpclient.Client] = _get_ipfs_client()
-
+@logger.catch(reraise=True)
+def _check_connection_to_ipfs_cluster_peer(socket, mode=LOCAL_IPFS_IS_CLUSTER_PEER, endpoint='/id'):
+    protocol = 'http'
+    try:
+        url = _build_url(mode, protocol, socket, endpoint)
+        if mode:
+            response = requests.get(url)
+        else:
+            response = requests.post(url)
+        logger.info(f"The check connection url is: {url}")
+    except Exception as e:
+            logger.error(f"An error occurred while getting IPFS cluster peer client: {e}")
+            logger.error(f"The problem url is : {url}")
+    else:
+        if response.status_code == requests.codes.ok:
+            return True
+        else:
+            return False
 
 @logger.catch(reraise=True)
 def publish_to_ipfs(file: tp.Union[os.PathLike[tp.AnyStr], tp.IO[bytes]]) -> tp.Tuple[str, str]:
     """publish file on IPFS"""
     logger.info("Publishing file to IPFS")
-
-    client = IPFS_CLIENT or _get_ipfs_client()
-    if client is None:
-        raise ConnectionError("Connection to IPFS node failed, cannot publish file")
-
-    result = client.add(file)
-    ipfs_hash: str = result["Hash"]
+    ipfs_cluster_peer_sockets = set(a.split("/")[2]+":"+a.split("/")[4] for a in tuple(LOCAL_IPFS_LIST.split(",")))
+    socket = None
+    for s in ipfs_cluster_peer_sockets:
+        if _check_connection_to_ipfs_cluster_peer(s):
+            socket = s
+            break
+    try:
+        assert socket != None
+    except AssertionError:
+        logger.error("It seems like there is no alive IPFS CLUSTER peer")
+    url = _build_url(LOCAL_IPFS_IS_CLUSTER_PEER, 'http', socket, '/add')
+    with open(file, 'rb') as fout:
+        files = {'upload_file': fout}
+        result = requests.post(url, files=files).json()
+    if LOCAL_IPFS_IS_CLUSTER_PEER:    
+        ipfs_hash: str = result["cid"]
+    else:
+        ipfs_hash: str = result["Hash"]
     ipfs_link: str = IPFS_GATEWAY_ADDRESS + ipfs_hash
     logger.info(f"File published to IPFS, hash: {ipfs_hash}")
     return ipfs_hash, ipfs_link


### PR DESCRIPTION
Idea:
To provide data replication the `IPFS Cluster` could be used. This `commit` provides support of IPFS Cluser Rest API endpoint `/add`, as well as switching by list of sockets given in `docker-compose.yml`.

Changes:
The function `publish_to_ipfs` was modified with using of `requests` module only. The useing of `ipfshttpclient2` module was denied. The function `_get_ipfs_client` was deleted.
The environment variable `LOCAL_IPFS_IS_CLUSTER_PEER` was introdused. The environment variable `PY_IPFS_HTTP_CLIENT_DEFAULT_ADDR` was renamed with `LOCAL_IPFS_LIST`.
Service `ipfsnode` was deleted from `docker-compose`.